### PR TITLE
Fix for -safe-string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_build
+property_tests.native
+redis_protocol.docdir

--- a/_tags
+++ b/_tags
@@ -1,1 +1,2 @@
 "src": include
+true: safe_string

--- a/src/redis_protocol.ml
+++ b/src/redis_protocol.ml
@@ -1,8 +1,8 @@
 type t =
-  | Simple_string of bytes
-  | Error of bytes
-  | Integer of bytes
-  | Bulk_string of bytes option
+  | Simple_string of string
+  | Error of string
+  | Integer of string
+  | Bulk_string of string option
   | Array of t array option
 
 module Resp = struct
@@ -10,38 +10,38 @@ module Resp = struct
   exception Simple_string_contains_CR_or_LF
 
   let rec encoding_length = function
-    | Simple_string s      -> 3+Bytes.length s
-    | Error s              -> 3+Bytes.length s
-    | Integer s            -> 3+Bytes.length s
+    | Simple_string s      -> 3+String.length s
+    | Error s              -> 3+String.length s
+    | Integer s            -> 3+String.length s
     | Bulk_string None     -> 5
-    | Bulk_string (Some s) -> 6+Bytes.length (Bytes.length s |> string_of_int)+Bytes.length s
+    | Bulk_string (Some s) -> 6+String.length (String.length s |> string_of_int)+String.length s
     | Array None           -> 5
-    | Array (Some ss)      -> 3+(Array.length ss |> string_of_int |> Bytes.length)+Array.fold_left (fun n t -> n+encoding_length t) 0 ss
+    | Array (Some ss)      -> 3+(Array.length ss |> string_of_int |> String.length)+Array.fold_left (fun n t -> n+encoding_length t) 0 ss
 
-  let ensure_no_crlf = Bytes.iter (function
+  let ensure_no_crlf = String.iter (function
     | '\r' | '\n' -> raise Simple_string_contains_CR_or_LF
     | _ -> ())
 
   let rec encode_to_buffer_exn t b =
-    let add_bytes s = Buffer.add_bytes b s in
+    let add_string s = Buffer.add_string b s in
     let crlf = "\r\n" in
     match t with
     | Simple_string s ->
-      ensure_no_crlf s; add_bytes "+"; add_bytes s; add_bytes crlf
+      ensure_no_crlf s; add_string "+"; add_string s; add_string crlf
     | Error s ->
-      ensure_no_crlf s; add_bytes "-"; add_bytes s; add_bytes crlf
+      ensure_no_crlf s; add_string "-"; add_string s; add_string crlf
     | Integer s ->
-      ensure_no_crlf s; add_bytes ":"; add_bytes s; add_bytes crlf
+      ensure_no_crlf s; add_string ":"; add_string s; add_string crlf
     | Bulk_string (Some s) ->
-      let n = Bytes.length s |> string_of_int in
-      add_bytes "$"; add_bytes n; add_bytes crlf; add_bytes s; add_bytes crlf
+      let n = String.length s |> string_of_int in
+      add_string "$"; add_string n; add_string crlf; add_string s; add_string crlf
     | Array (Some ss) ->
       let n = Array.length ss |> string_of_int in
-      add_bytes "*"; add_bytes n; add_bytes crlf; Array.iter (fun t -> encode_to_buffer_exn t b) ss
-    | Bulk_string None -> add_bytes "$-1\r\n"
-    | Array None -> add_bytes "*-1\r\n"
+      add_string "*"; add_string n; add_string crlf; Array.iter (fun t -> encode_to_buffer_exn t b) ss
+    | Bulk_string None -> add_string "$-1\r\n"
+    | Array None -> add_string "*-1\r\n"
 
-  let encode_exn t = encoding_length t |> Buffer.create |> fun b -> encode_to_buffer_exn t b; Buffer.to_bytes b
+  let encode_exn t = encoding_length t |> Buffer.create |> fun b -> encode_to_buffer_exn t b; Buffer.to_bytes b |> Bytes.to_string
 
   let encode t = try Some (encode_exn t) with Simple_string_contains_CR_or_LF -> None
 
@@ -51,13 +51,13 @@ module Resp = struct
 
   let check b i c = if b.[i] <> c then raise Invalid_encoding
 
-  let find_and_skip_crlf b i = let j = Bytes.index_from b i '\r' in check b (j+1) '\n'; j+2
+  let find_and_skip_crlf b i = let j = String.index_from b i '\r' in check b (j+1) '\n'; j+2
 
   let decode_length b = let rec loop n i = if b.[i] <> '\r' then loop (10*n+(Char.code b.[i]-48)) (i+1) else (check b (i+1) '\n';i+2,n) in loop 0
 
-  let decode_simple_string b i = find_and_skip_crlf b i |> fun j -> j,Bytes.sub b i (j-i-2)
+  let decode_simple_string b i = find_and_skip_crlf b i |> fun j -> j,String.sub b i (j-i-2)
 
-  let decode_bulk_string b i = let j,n = decode_length b i in let s = Bytes.sub b j n in check b (j+n) '\r';check b (j+n+1) '\n'; j+n+2,s
+  let decode_bulk_string b i = let j,n = decode_length b i in let s = String.sub b j n in check b (j+n) '\r';check b (j+n+1) '\n'; j+n+2,s
 
   let rec decode_array b i =
     let rec loop acc j n = if n = 0 then j,acc else let j,t = decode_from b j in loop (t::acc) j (n-1) in
@@ -77,7 +77,7 @@ module Resp = struct
 
   let decode_exn b =
     let i,t = try decode_from b 0 with _ -> raise Invalid_encoding
-    in if i <> Bytes.length b then raise (Trailing_garbage (t,i)) else t
+    in if i <> String.length b then raise (Trailing_garbage (t,i)) else t
 
   let decode b = try Some (decode_exn b) with Invalid_encoding -> None
 

--- a/src/redis_protocol.mli
+++ b/src/redis_protocol.mli
@@ -2,10 +2,10 @@
 
 (** Redis protocol messages *)
 type t =
-  | Simple_string of bytes (** Simple (binary-unsafe) strings *)
-  | Error of bytes
-  | Integer of bytes
-  | Bulk_string of bytes option (** Bulk (binary-safe) string if Some and null string if None *)
+  | Simple_string of string (** Simple (binary-unsafe) strings *)
+  | Error of string
+  | Integer of string
+  | Bulk_string of string option (** Bulk (binary-safe) string if Some and null string if None *)
   | Array of t array option (** Array if Some and null array if None *)
 
 (** Return a string representation of the protocol message (as OCaml source) *)
@@ -19,19 +19,19 @@ val to_string_hum : t -> string
 module Resp : sig
 
   (** Return the encoding of the message as a byte string. *)
-  val encode : t -> bytes option
+  val encode : t -> string option
 
   (** Return the encoding of the message as a byte string. *)
-  val encode_exn : t -> bytes
+  val encode_exn : t -> string
 
   (** Append the encoding of the message to the given buffer. *)
   val encode_to_buffer_exn : t -> Buffer.t -> unit
 
   (** Try to decode the given byte string. *)
-  val decode : bytes -> t option
+  val decode : string -> t option
 
   (** Try to decode the given byte string (throws [Invalid_encoding] and [Trailing_garbage].  *)
-  val decode_exn : bytes -> t
+  val decode_exn : string -> t
 
   (** The message could not be encoded because a simple string contains a CR or LF character. *)
   exception Simple_string_contains_CR_or_LF
@@ -50,29 +50,29 @@ module Redis_command : sig
 
   (** Build a command with an arbitrary number of arguments, e.g.
     {[build "SET" ["fooKey";"barValue"]]} *)
-  val build : command:bytes -> bytes list -> t
+  val build : command:string -> string list -> t
 
   (** Build a command with no arguments, e.g.
     {[build0 "SHUTDOWN"]} *)
-  val build0 : bytes -> t
+  val build0 : string -> t
 
   (** Build a command with 1 argument, e.g.
     {[build1 "INCR" "intKey"]} *)
-  val build1 : command:bytes -> bytes -> t
+  val build1 : command:string -> string -> t
 
   (** Build a command with 2 arguments *)
-  val build2 : command:bytes -> bytes -> bytes -> t
+  val build2 : command:string -> string -> string -> t
 
   (** Build a command with 3 arguments *)
-  val build3 : command:bytes -> bytes -> bytes -> bytes -> t
+  val build3 : command:string -> string -> string -> string -> t
 
   (** Build a command with 4 arguments *)
-  val build4 : command:bytes -> bytes -> bytes -> bytes -> bytes -> t
+  val build4 : command:string -> string -> string -> string -> string -> t
 
   (** Build a command with 5 arguments *)
-  val build5 : command:bytes -> bytes -> bytes -> bytes -> bytes -> bytes -> t
+  val build5 : command:string -> string -> string -> string -> string -> string -> t
 
   (** Build a command with 6 arguments *)
-  val build6 : command:bytes -> bytes -> bytes -> bytes -> bytes -> bytes -> bytes -> t
+  val build6 : command:string -> string -> string -> string -> string -> string -> string -> t
 
 end

--- a/test/property_tests.ml
+++ b/test/property_tests.ml
@@ -14,7 +14,7 @@ module Well_formed = struct
     for i = 0 to Array.length ts - 1 do
       let t = ts.(i) in
       let s = Resp.encode_exn t in
-      let n = Bytes.length s in
+      let n = String.length s in
       if n > !max_encoding_length then max_encoding_length := n;
       assert_equal ~actual:(Resp.decode_exn s) ~expected:t
     done


### PR DESCRIPTION
Fixes #2. This is required for OCaml 4.06.0, since `-safe-string` has become the default. Unlike stated in #2, I believe this is not a breaking change, since without `-safe-string`, `bytes` is an alias for `string`, which is the only interface change.